### PR TITLE
Add examples for PAN-OS upgrade assurance scripts

### DIFF
--- a/python/pan-os-upgrade-assurance/README.md
+++ b/python/pan-os-upgrade-assurance/README.md
@@ -1,0 +1,174 @@
+# PAN-OS Upgrade Assurance Examples
+
+This README provides an overview of our PAN-OS Upgrade Assurance Examples and guides you through the setup and execution process. 🚀
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Setup](#setup)
+- [Health Check Script Example](#health-check-script-example)
+- [Readiness Checks Script Example](#readiness-checks-script-example)
+- [Snapshot Example Script Structure](#snapshot-example-script-structure)
+
+## Overview
+
+Our PAN-OS Health Check Tool is designed to perform health checks on Palo Alto Networks firewalls using the `panos_upgrade_assurance` package. This tool allows you to run specific health checks and view the results, helping to ensure the proper functioning of your firewall. 🎯
+
+## Prerequisites
+
+Before getting started, ensure that you have the following prerequisites installed on your local machine:
+
+- Python (version 3.6+) 🐍
+- pip (Python package manager) 📦
+
+## Setup
+
+### Creating a Python Virtual Environment
+
+To create a Python virtual environment, follow these steps:
+
+1. Open a terminal and navigate to the project directory.
+2. Run the following command to create a virtual environment:
+
+    ```bash
+    python -m venv venv
+    ```
+
+3. Activate the virtual environment:
+
+    - For Windows:
+
+        ```bash
+        venv\Scripts\activate
+        ```
+
+    - For macOS and Linux:
+
+        ```bash
+        source venv/bin/activate
+        ```
+
+### Installing Dependencies
+
+To install the required Python packages within your virtual environment, execute:
+
+```bash
+pip install panos_upgrade_assurance
+```
+
+### Configuring Environment Variables
+
+This script doesn't use environment variables directly. However, you may want to securely store your firewall credentials in environment variables or a configuration file for production use.
+
+## Health Check Script Example
+
+Our Python script (`healthcheck_example.py`) is structured as follows:
+
+1. `run_health_checks`: This function initializes a FirewallProxy, creates a CheckFirewall instance, and runs the specified health checks.
+2. `print_health_check_results`: This function prints the results of the health checks in a formatted manner.
+3. `run_health_checks_example`: This function demonstrates how to use the other functions to perform health checks on a firewall.
+
+### Execution Workflow
+
+To execute our Python script, follow these steps:
+
+1. Ensure that you have activated the Python virtual environment.
+2. Run the following command:
+
+    ```bash
+    python healthcheck_example.py
+    ```
+
+### Command-line Arguments
+
+The script currently doesn't support command-line arguments. All parameters are hardcoded in the `run_health_checks_example` function.
+
+### Example Usage
+
+The script will run the health checks defined in the `run_health_checks_example` function. Currently, it checks for the "device_root_certificate_issue".
+
+Example output:
+
+```
+device_root_certificate_issue: Passed
+```
+
+or
+
+```
+device_root_certificate_issue: Failed
+  Reason: [Reason for failure]
+```
+
+## Readiness Checks Script Example
+
+Our Python script (`readiness_checks_example.py`) is structured as follows:
+
+```python
+from panos_upgrade_assurance.firewall_proxy import FirewallProxy
+from panos_upgrade_assurance.check_firewall import CheckFirewall
+
+def run_readiness_checks(hostname: str, username: str, password: str, checks_configuration: list) -> dict:
+    # Implementation details...
+
+def print_check_results(results: dict) -> None:
+    # Implementation details...
+
+def run_readiness_checks_example():
+    # Implementation details...
+
+if __name__ == "__main__":
+    run_readiness_checks_example()
+```
+
+This script performs readiness checks on a firewall using the panos_upgrade_assurance library. Here's a breakdown of its structure:
+
+1. `run_readiness_checks`: This function initializes a FirewallProxy, creates a CheckFirewall instance, and runs the specified readiness checks.
+2. `print_check_results`: This function prints the results of the readiness checks in a formatted manner.
+3. `run_readiness_checks_example`: This function demonstrates how to use the `run_readiness_checks` function with a sample configuration.
+
+### Execution Workflow
+
+To execute our Python script, follow these steps:
+
+1. Ensure that you have activated the Python virtual environment.
+2. Run the following command:
+
+    ```bash
+    python readiness_checks_example.py
+    ```
+
+## Snapshot Example Script Structure
+
+Our Python script (`snapshot_compare_example.py`) is structured as follows:
+
+1. Import necessary modules from `panos_upgrade_assurance`.
+2. Define the `take_and_compare_snapshots` function to take pre- and post-upgrade snapshots and compare them.
+3. Define helper functions `print_changes` and `print_results` to format and display the comparison results.
+4. In the main execution block:
+    - Define snapshot and comparison configurations.
+    - Call `take_and_compare_snapshots` with firewall credentials and configurations.
+    - Print the results using the helper functions.
+
+### Execution Workflow
+
+To execute our Python script, follow these steps:
+
+1. Ensure that you have activated the Python virtual environment.
+2. Run the following command:
+
+    ```bash
+    python snapshot_compare_example.py
+    ```
+
+This will:
+1. Take a pre-upgrade snapshot of the specified firewall areas.
+2. Simulate an upgrade (not actually performed in this example).
+3. Take a post-upgrade snapshot.
+4. Compare the snapshots based on the defined comparison configuration.
+5. Print the results, showing any changes or issues detected.
+
+Note: Remember to replace the firewall credentials in the script with your own before running.
+
+Happy health checking! 😄

--- a/python/pan-os-upgrade-assurance/healthcheck_example.py
+++ b/python/pan-os-upgrade-assurance/healthcheck_example.py
@@ -1,0 +1,103 @@
+from panos_upgrade_assurance.firewall_proxy import FirewallProxy
+from panos_upgrade_assurance.check_firewall import CheckFirewall
+
+
+def run_health_checks(
+    hostname: str, username: str, password: str, health_checks: list
+) -> dict:
+    """
+    Run health checks on a firewall using the CheckFirewall class.
+
+    This function initializes a FirewallProxy instance, creates a CheckFirewall instance,
+    and executes the specified health checks on the firewall.
+
+    Args:
+        hostname (str): The hostname of the firewall.
+        username (str): The API username for authentication.
+        password (str): The API password for authentication.
+        health_checks (list): A list of health checks to run.
+
+    Returns:
+        dict: A dictionary containing the results of the health checks.
+
+    Mermaid Workflow:
+        ```mermaid
+        graph TD
+            A[Start] --> B[Initialize FirewallProxy]
+            B --> C[Create CheckFirewall instance]
+            C --> D[Run health checks]
+            D --> E[Return results]
+            E --> F[End]
+        ```
+    """
+    # Initialize the FirewallProxy
+    firewall = FirewallProxy(
+        hostname=hostname,
+        api_username=username,
+        api_password=password,
+    )
+
+    # Create a CheckFirewall instance
+    checks = CheckFirewall(firewall)
+
+    # Run health checks
+    results = checks.run_health_checks(health_checks)
+
+    return results
+
+
+def print_health_check_results(results: dict) -> None:
+    """
+    Print the results of the health checks in a formatted manner.
+
+    Args:
+        results (dict): A dictionary containing the results of the health checks.
+
+    Returns:
+        None
+    """
+    for check, result in results.items():
+        print(f"{check}: {'Passed' if result['state'] else 'Failed'}")
+        if not result["state"]:
+            print(f"  Reason: {result['reason']}")
+
+
+def run_health_checks_example() -> None:
+    """
+    Run an example of health checks on a firewall and print the results.
+
+    This function demonstrates how to use the run_health_checks function
+    and print_health_check_results function to perform health checks on a firewall.
+
+    Returns:
+        None
+
+    Mermaid Workflow:
+        ```mermaid
+        graph TD
+            A[Start] --> B[Define firewall credentials]
+            B --> C[Define health checks]
+            C --> D[Run health checks]
+            D --> E[Print results]
+            E --> F[End]
+        ```
+    """
+    # Define firewall credentials
+    hostname = "austin-fw1.cdot.io"
+    username = "officehours"
+    password = "paloalto123"
+
+    # Define health checks
+    health_checks = [
+        "device_root_certificate_issue",
+    ]
+
+    # Run health checks
+    results = run_health_checks(hostname, username, password, health_checks)
+
+    # Print results
+    print_health_check_results(results)
+
+
+if __name__ == "__main__":
+    run_health_checks_example()

--- a/python/pan-os-upgrade-assurance/readiness_checks_example.py
+++ b/python/pan-os-upgrade-assurance/readiness_checks_example.py
@@ -1,0 +1,109 @@
+from panos_upgrade_assurance.firewall_proxy import FirewallProxy
+from panos_upgrade_assurance.check_firewall import CheckFirewall
+
+
+def run_readiness_checks(
+    hostname: str, username: str, password: str, checks_configuration: list
+) -> dict:
+    """
+    Run a series of readiness checks on a firewall using the CheckFirewall class.
+
+    This function initializes a FirewallProxy instance, creates a CheckFirewall instance,
+    and executes the specified readiness checks.
+
+    Args:
+        hostname (str): The hostname of the firewall.
+        username (str): The API username for authentication.
+        password (str): The API password for authentication.
+        checks_configuration (list): A list of checks to be performed.
+
+    Returns:
+        dict: A dictionary containing the results of the readiness checks.
+
+    Mermaid Workflow:
+        ```mermaid
+        graph TD
+            A[Initialize FirewallProxy] --> B[Create CheckFirewall instance]
+            B --> C[Run readiness checks]
+            C --> D[Return results]
+        ```
+    """
+    # Initialize the FirewallProxy
+    firewall = FirewallProxy(
+        hostname=hostname,
+        api_username=username,
+        api_password=password,
+    )
+
+    # Create a CheckFirewall instance
+    checks = CheckFirewall(firewall)
+
+    # Run the readiness checks
+    results = checks.run_readiness_checks(checks_configuration)
+
+    return results
+
+
+def print_check_results(results: dict) -> None:
+    """
+    Print the results of the readiness checks.
+
+    Args:
+        results (dict): A dictionary containing the results of the readiness checks.
+
+    Returns:
+        None
+    """
+    for check, result in results.items():
+        print(f"{check}: {'Passed' if result['state'] else 'Failed'}")
+        if not result["state"]:
+            print(f"  Reason: {result['reason']}")
+
+
+def run_readiness_checks_example():
+    """
+    Demonstrate how to run readiness checks and print the results.
+
+    This function shows an example of how to use the run_readiness_checks function
+    and print the results using print_check_results.
+
+    The checks_configuration list specifies the checks to be performed, which can include: - 'active_support': Check
+    if active support is enabled. - 'candidate_config': Check if there is a candidate configuration. -
+    'expired_licenses': Check for expired licenses. - 'jobs': Check for any running jobs. - 'ntp_sync': Check if NTP
+    is synchronized. - 'panorama': Check if Panorama is connected. - {'content_version': {'version': '8634-7678'}}:
+    Check if the content version matches the specified version. - {'free_disk_space': {'image_version':
+    '10.1.6-h6'}}: Check if there is enough free disk space for the specified image version.
+
+    Mermaid Workflow:
+        ```mermaid
+        graph TD
+            A[Define checks configuration] --> B[Run readiness checks]
+            B --> C[Print check results]
+        ```
+    """
+    # Define the checks to run
+    checks_configuration = [
+        "active_support",
+        "candidate_config",
+        "expired_licenses",
+        "jobs",
+        "ntp_sync",
+        "panorama",
+        {"content_version": {"version": "8634-7678"}},
+        {"free_disk_space": {"image_version": "10.1.6-h6"}},
+    ]
+
+    # Run the readiness checks
+    results = run_readiness_checks(
+        hostname="austin-fw1.cdot.io",
+        username="officehours",
+        password="paloalto123",
+        checks_configuration=checks_configuration,
+    )
+
+    # Print the results
+    print_check_results(results)
+
+
+if __name__ == "__main__":
+    run_readiness_checks_example()

--- a/python/pan-os-upgrade-assurance/snapshots_example.py
+++ b/python/pan-os-upgrade-assurance/snapshots_example.py
@@ -1,0 +1,156 @@
+from panos_upgrade_assurance.firewall_proxy import FirewallProxy
+from panos_upgrade_assurance.check_firewall import CheckFirewall
+from panos_upgrade_assurance.snapshot_compare import SnapshotCompare
+
+
+def take_and_compare_snapshots(
+    hostname: str,
+    username: str,
+    password: str,
+    config_snapshots: list,
+    config_comparison: list,
+) -> dict:
+    """
+    Take pre- and post-upgrade snapshots of a firewall and compare them.
+
+    This function initializes a FirewallProxy, takes pre- and post-upgrade snapshots,
+    and compares them using the provided configuration.
+
+    Args:
+        hostname (str): The hostname of the firewall.
+        username (str): The API username for authentication.
+        password (str): The API password for authentication.
+        config_snapshots (list): A list of areas to snapshot.
+        config_comparison (list): A list of configurations for snapshot comparison.
+
+    Returns:
+        dict: A dictionary containing the comparison snapshot_comparison_result.
+
+    Mermaid Workflow:
+        ```mermaid
+        graph TD
+            A[Start] --> B[Initialize FirewallProxy]
+            B --> C[Create CheckFirewall instance]
+            C --> D[Take pre-upgrade snapshot]
+            D --> E[Perform upgrade (not shown)]
+            E --> F[Take post-upgrade snapshot]
+            F --> G[Compare snapshots]
+            G --> H[Return snapshot_comparison_result]
+        ```
+    """
+    # Initialize the FirewallProxy
+    firewall = FirewallProxy(
+        hostname=hostname, api_username=username, api_password=password
+    )
+
+    # Create a CheckFirewall instance
+    checks = CheckFirewall(firewall)
+
+    # Take pre-upgrade snapshot
+    print("Taking pre-upgrade snapshot...")
+    pre_upgrade_snapshot = checks.run_snapshots(config_snapshots)
+
+    # Perform upgrade here (not shown in this example)
+    # ...
+
+    # Take post-upgrade snapshot
+    print("Taking post-upgrade snapshot...")
+    post_upgrade_snapshot = checks.run_snapshots(config_snapshots)
+
+    # Compare snapshots
+    compare = SnapshotCompare(pre_upgrade_snapshot, post_upgrade_snapshot)
+
+    # Run comparison
+    snapshot_comparison_result = compare.compare_snapshots(config_comparison)
+
+    return snapshot_comparison_result
+
+
+def print_changes(changes: dict, indent: str = "") -> None:
+    """
+    Recursively print the changes detected in the snapshot comparison.
+
+    Args:
+        changes (dict): The dictionary containing the changes.
+        indent (str, optional): The indentation string for formatting. Defaults to "".
+
+    Returns:
+        None
+    """
+    if isinstance(changes, dict):
+        for key, value in changes.items():
+            if key in ["passed", "missing_keys", "added_keys"]:
+                continue
+            print(f"{indent}{key}:")
+            print_changes(value, indent + "  ")
+    elif isinstance(changes, list):
+        for item in changes:
+            print(f"{indent}- {item}")
+    else:
+        print(f"{indent}{changes}")
+
+
+def print_results(snapshot_comparison_result: dict) -> None:
+    """
+    Print the results of the snapshot comparison in a formatted manner.
+
+    Args:
+        snapshot_comparison_result (dict): The dictionary containing the comparison results.
+
+    Returns:
+        None
+    """
+    for area, result in snapshot_comparison_result.items():
+        print(f"\n{area.upper()} comparison:")
+        if result.get("passed", True):
+            print("  No significant changes detected.")
+        else:
+            print("  Changes detected:")
+            if "missing" in result and not result["missing"].get("passed", True):
+                print(f"    Missing entries: {result['missing']['missing_keys']}")
+            if "added" in result and not result["added"].get("passed", True):
+                print(f"    Added entries: {result['added']['added_keys']}")
+            if "changed" in result and not result["changed"].get("passed", True):
+                print("    Changed entries:")
+                print_changes(result["changed"].get("changed_raw", {}), "      ")
+            if "count_change_percentage" in result:
+                print(
+                    f"    Count change percentage: {result['count_change_percentage']['change_percentage']}%"
+                )
+                print(
+                    f"    Count change threshold: {result['count_change_percentage']['change_threshold']}%"
+                )
+
+
+# Main execution
+if __name__ == "__main__":
+    # Define the snapshot areas
+    snapshot_config = [
+        "nics",
+        "routes",
+        "license",
+        "arp_table",
+        "content_version",
+        "session_stats",
+        "ip_sec_tunnels",
+    ]
+
+    # Define comparison configuration
+    comparison_config = [
+        {"routes": {"count_change_threshold": 10}},
+        {"arp_table": {"properties": ["!ttl"]}},
+        "content_version",
+        {"session_stats": {"thresholds": [{"num-max": 10}, {"num-tcp": 10}]}},
+    ]
+
+    # Take snapshots and compare
+    results = take_and_compare_snapshots(
+        hostname="austin-fw1.cdot.io",
+        username="officehours",
+        password="paloalto123",
+        config_snapshots=snapshot_config,
+        config_comparison=comparison_config,
+    )
+
+    # Print snapshot_comparison_result
+    print_results(results)


### PR DESCRIPTION
This commit includes new examples for Palo Alto Networks (PAN-OS) upgrade assurance scripts in Python. The additions include health check, readiness check, and snapshot comparison examples. Moreover, these scripts demonstrate how to initialize a FirewallProxy, create a CheckFirewall instance, run specified checks or take snapshots, and then print the results. Lastly, the commit provides a README file for these examples, outlining the setup process and usage details for each script.