### PR TITLE
Add Dockerfile for Jenkins agent with kubectl setup

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -138,15 +138,19 @@ FROM jenkins/inbound-agent:latest
 
 USER root
 
-# Install kubectl and git
+# Install kubectl
 RUN apt-get update && \
-    apt-get install -y apt-transport-https gnupg2 curl ca-certificates git && \
-    curl -fsSL https://apt.kubernetes.io/doc/apt-key.gpg | apt-key add - && \
-    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list && \
+    apt-get install -y apt-transport-https gnupg2 curl ca-certificates && \
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
     apt-get update && \
-    apt-get install -y kubectl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# Download kubectl binary
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+
+# Make kubectl executable and move it to a directory in PATH
+RUN chmod +x kubectl && mv kubectl /usr/local/bin/
 
 USER jenkins
 ```

--- a/jenkins/docker/Dockerfile
+++ b/jenkins/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM jenkins/inbound-agent:latest
+
+USER root
+
+# Install kubectl
+RUN apt-get update && \
+    apt-get install -y apt-transport-https gnupg2 curl ca-certificates && \
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
+    apt-get update && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download kubectl binary
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+
+# Make kubectl executable and move it to a directory in PATH
+RUN chmod +x kubectl && mv kubectl /usr/local/bin/
+
+USER jenkins


### PR DESCRIPTION
A new Dockerfile for the Jenkins inbound agent has been added to automate the installation and setup of kubectl. The README.md file has also been updated to reflect this change by removing the installation instructions and aligning the steps with the Dockerfile.